### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,8 @@
 name: Shell Script Linter
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main", "test" ]


### PR DESCRIPTION
Potential fix for [https://github.com/buildplan/du_setup/security/code-scanning/3](https://github.com/buildplan/du_setup/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only needs to read the repository contents (e.g., to lint the shell script), we will set `contents: read`. This ensures that the workflow has the minimum required permissions and no write access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
